### PR TITLE
Set repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "doc": "doc",
     "test": "tests"
   },
-  "repository": "",
+  "repository": "https://github.com/shipshapecode/ember-smooth-scroll.git",
   "scripts": {
     "build": "ember build",
     "start": "ember server",


### PR DESCRIPTION
So that the NPM registry can pick it up and downstream stuff like [Ember Observer](https://emberobserver.com/) can show/use it.